### PR TITLE
投稿ページの作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,60 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user
+  before_action :ensure_correct_user, {only: [:edit, :update, :destroy]}
   def index
+    @posts = Post.all.order(created_at: :desc).page(params[:page]).without_count.per(5)
+  end
+
+  def show
+    @post =Post.find_by(id: params[:id])
+    @user = @post.user
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.new(post_params)
+    if @post.save
+      flash[:notice] = "投稿を作成しました"
+      redirect_to("/posts")
+    else
+      render("posts/new")
+    end
+  end
+
+  def edit
+    @post = Post.find_by(id: params[:id])
+  end
+
+  def update
+    @post = Post.find_by(id: params[:id])
+    if @post.update(post_params)
+      flash[:notice] = "投稿を編集しました"
+      redirect_to("/posts")
+    else
+      render("posts/edit")
+    end
+  end
+
+  def destroy
+    @post = Post.find_by(id: params[:id])
+    @post.destroy
+    flash[:notice] = "投稿を削除しました"
+    redirect_to("/posts")
+  end
+
+  def ensure_correct_user
+    @post = Post.find_by(id: params[:id])
+    if @post.user_id != @current_user.id
+      flash[:notice] = "いたずらはダメ"
+      redirect_to("/posts")
+    end
+  end
+
+private
+  def post_params
+    params.require(:post).permit(:content).merge(user_id: @current_user.id)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,10 @@
 class Post < ApplicationRecord
+  validates :content, {presence: true, length: {maximum: 140}}
+  validates :user_id, {presence: true}
+
+
+  has_many :likes, dependent: :destroy
+  def user
+    return User.find_by(id: self.user_id)
+  end
 end

--- a/app/views/posts/edit.html.haml
+++ b/app/views/posts/edit.html.haml
@@ -1,0 +1,11 @@
+.main.posts-new
+  .container
+    %h1.form-heading 編集する
+    = form_with(model: @post, local: true) do |form|
+      .form
+        .form-body
+          - @post.errors.full_messages.each do |message| 
+            .form-error
+              =message
+          = form.text_area :content
+          = form.submit "保存"

--- a/app/views/posts/index.html.haml
+++ b/app/views/posts/index.html.haml
@@ -1,1 +1,15 @@
-tanomu
+.main.posts-index
+  .container
+    .scroll-js
+      .j-scroll
+        - @posts.each do |post|
+          .posts-index-item
+            .post-left
+              = image_tag post.user.image.url
+            .post-right
+              .post-user-name
+                = link_to(post.user.nickname, "/users/#{post.user.id}")
+              = link_to(post.content, "/posts/#{post.id}")
+        .skill-list
+          = link_to_prev_page @posts, '前のページ', class: "prev"
+          = link_to_next_page @posts, '次のページ', class: "next"

--- a/app/views/posts/new.html.haml
+++ b/app/views/posts/new.html.haml
@@ -1,0 +1,11 @@
+.main.posts-new
+  .container
+    %h1.form-heading 投稿する
+    = form_with model: @post, local: true do |f|
+      .form
+        .form-body
+          - @post.errors.full_messages.each do |message|
+            .form-error
+              =message
+          = f.text_area :content, placeholder: :"お話帳", class: :form_text
+          = f.submit "投稿", class: :form_btn

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,0 +1,17 @@
+.main.posts-show
+  .container
+    .posts-show-item
+      .post-user-name
+        = image_tag @user.image.url
+        = link_to(@user.nickname, "/users/#{@user.id}")
+      %p
+        = @post.content
+      .post-time
+        = @post.created_at
+      %ul#likeBtn
+        = render partial: 'likes/like', locals: {post: @post}
+        
+      -if @post.user_id == @current_user.id
+        .post-menus
+          = link_to("編集", "/posts/#{@post.id}/edit")
+          = link_to("削除", "/posts/#{@post.id}", method: :delete)


### PR DESCRIPTION
#WHAT
1.投稿一覧ページ、詳細ページの作成
2.編集・削除機能の追加
3.空の投稿を出来ないようにする
4.新規投稿、編集、削除のフラッシュメッセージの表示
#WHY
1.サイト利用者が自由に投稿できるように
2.サイト利用者が自由に投稿の編集と削除を行えるように
3.悪質な投稿を防ぐため。（例）空の投稿ばかりで困らないように
4.ユーザーが投稿や編集したことが可視化できるようにするため